### PR TITLE
Use cache for get_all_entries

### DIFF
--- a/frog_api/cache.py
+++ b/frog_api/cache.py
@@ -1,0 +1,38 @@
+from django.core.cache import cache
+from rest_framework.utils.serializer_helpers import ReturnDict
+
+ENTRIES_CACHE_TIMEOUT = 7200  # 2 hours
+
+
+def _entries_cache_key(project_slug: str, version_slug: str, category_slug: str) -> str:
+    return f"entries_{project_slug}_{version_slug}_{category_slug}"
+
+
+def get_entries_cache(
+    project_slug: str, version_slug: str, category_slug: str
+) -> ReturnDict | None:
+    """
+    Fetches cached entries data.
+    """
+    return cache.get(_entries_cache_key(project_slug, version_slug, category_slug))
+
+
+def set_entries_cache(
+    project_slug: str, version_slug: str, category_slug: str, data: ReturnDict
+):
+    """
+    Updates cached entries data.
+    """
+    return cache.set(_entries_cache_key(project_slug, version_slug, category_slug), data, ENTRIES_CACHE_TIMEOUT)
+
+
+def invalidate_entries_cache(project_slug: str, version_slug: str, data: ReturnDict):
+    """
+    Invalidates all affected entries caches.
+    """
+    all_categories = set()
+    for entry in data["entries"]:
+        for category in entry["categories"]:
+            all_categories.add(category)
+    for category_slug in all_categories:
+        cache.delete(_entries_cache_key(project_slug, version_slug, category_slug))

--- a/frog_api/cache.py
+++ b/frog_api/cache.py
@@ -20,18 +20,20 @@ def get_entries_cache(
 
 def set_entries_cache(
     project_slug: str, version_slug: str, category_slug: str, data: ReturnDict
-):
+) -> None:
     """
     Updates cached entries data.
     """
-    return cache.set(
+    cache.set(
         _entries_cache_key(project_slug, version_slug, category_slug),
         data,
         ENTRIES_CACHE_TIMEOUT,
     )
 
 
-def invalidate_entries_cache(project_slug: str, version_slug: str, data: ReturnDict):
+def invalidate_entries_cache(
+    project_slug: str, version_slug: str, data: ReturnDict
+) -> None:
     """
     Invalidates all affected entries caches.
     """

--- a/frog_api/cache.py
+++ b/frog_api/cache.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from django.core.cache import cache
 from rest_framework.utils.serializer_helpers import ReturnDict
 
@@ -10,7 +11,7 @@ def _entries_cache_key(project_slug: str, version_slug: str, category_slug: str)
 
 def get_entries_cache(
     project_slug: str, version_slug: str, category_slug: str
-) -> ReturnDict | None:
+) -> Optional[ReturnDict]:
     """
     Fetches cached entries data.
     """
@@ -23,7 +24,11 @@ def set_entries_cache(
     """
     Updates cached entries data.
     """
-    return cache.set(_entries_cache_key(project_slug, version_slug, category_slug), data, ENTRIES_CACHE_TIMEOUT)
+    return cache.set(
+        _entries_cache_key(project_slug, version_slug, category_slug),
+        data,
+        ENTRIES_CACHE_TIMEOUT,
+    )
 
 
 def invalidate_entries_cache(project_slug: str, version_slug: str, data: ReturnDict):

--- a/frog_api/views/data.py
+++ b/frog_api/views/data.py
@@ -3,7 +3,11 @@ from typing import Any
 from django.db import models
 from django.template.defaultfilters import title
 
-from frog_api.cache import invalidate_entries_cache, set_entries_cache, get_entries_cache
+from frog_api.cache import (
+    invalidate_entries_cache,
+    set_entries_cache,
+    get_entries_cache,
+)
 from frog_api.exceptions import (
     InvalidDataException,
     NoEntriesException,
@@ -52,7 +56,7 @@ def get_all_entries(
     version = get_version(version_slug, project)
     category = get_category(category_slug, version)
 
-    entries = Entry.objects.filter(category=category).prefetch_related('measures')
+    entries = Entry.objects.filter(category=category).prefetch_related("measures")
 
     data = EntrySerializer(entries, many=True).data
     set_entries_cache(project_slug, version_slug, category_slug, data)

--- a/frog_api/views/data.py
+++ b/frog_api/views/data.py
@@ -52,7 +52,7 @@ def get_all_entries(
     version = get_version(version_slug, project)
     category = get_category(category_slug, version)
 
-    entries = Entry.objects.filter(category=category)
+    entries = Entry.objects.filter(category=category).prefetch_related('measures')
 
     data = EntrySerializer(entries, many=True).data
     set_entries_cache(project_slug, version_slug, category_slug, data)

--- a/frog_api/views/structure.py
+++ b/frog_api/views/structure.py
@@ -42,6 +42,7 @@ class ProjectStructureView(APIView):
         Create a new project.
         """
         request_ser = CreateProjectSerializer(data=request.data)
+        request_ser.is_valid(raise_exception=True)
 
         validate_ultimate_api_key(request_ser.data["api_key"])
 
@@ -58,11 +59,9 @@ class VersionStructureView(APIView):
 
     def post(self, request: Request, project_slug: str, version_slug: str) -> Response:
         request_ser = CreateVersionSerializer(data=request.data)
+        request_ser.is_valid(raise_exception=True)
 
         project = get_project(project_slug)
-
-        if not request_ser.is_valid():
-            return Response(request_ser.errors, status=status.HTTP_400_BAD_REQUEST)
 
         validate_api_key(request_ser.data["api_key"], project)
 


### PR DESCRIPTION
Tests with `?mode=all` returning 2200 entries:

```
# before
$ time curl -s http://127.0.0.1:8000/data/prime/0/dol/?mode=all >/dev/null

real    0m0.699s
user    0m0.000s
sys     0m0.003s

# with prefetch_related (avoids N+1 queries)
$ time curl -s http://127.0.0.1:8000/data/prime/0/dol/?mode=all >/dev/null

real    0m0.268s
user    0m0.003s
sys     0m0.000s

# with serialized cache
$ time curl -s http://127.0.0.1:8000/data/prime/0/dol/?mode=all >/dev/null

real    0m0.012s
user    0m0.000s
sys     0m0.004s
```